### PR TITLE
Add badges on readm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # A 3rd-party SDK for claude-code Hooks
 
+[![CI](https://github.com/mizunashi-mana/claude-code-hook-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/mizunashi-mana/claude-code-hook-sdk/actions/workflows/test.yml)
+[![npm version](https://badge.fury.io/js/@mizunashi_mana%2Fclaude-code-hook-sdk.svg)](https://www.npmjs.com/package/@mizunashi_mana/claude-code-hook-sdk)
+[![npm downloads](https://img.shields.io/npm/dm/@mizunashi_mana/claude-code-hook-sdk.svg)](https://www.npmjs.com/package/@mizunashi_mana/claude-code-hook-sdk)
+[![License](https://img.shields.io/npm/l/@mizunashi_mana/claude-code-hook-sdk.svg)](https://github.com/mizunashi-mana/claude-code-hook-sdk/blob/main/LICENSE)
+
 A TypeScript SDK to write claude-code hooks easily with type safety, dependency injection, and comprehensive testing support.
 
 ## Quick Start

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -20,6 +20,15 @@ async function gitTag(version: string, dryRun: boolean): Promise<void> {
 }
 
 async function checkGitTagExists(version: string): Promise<boolean> {
+  // First, fetch the specific tag from remote
+  try {
+    console.log(`→ Fetching tag v${version} from remote...`);
+    await execFileAsync('git', ['fetch', 'origin', `tag`, `v${version}`]);
+  } catch {
+    // Tag doesn't exist on remote, which is fine
+  }
+
+  // Then check if tag exists locally (which now includes remote tags we just fetched)
   try {
     await execFileAsync('git', ['rev-parse', `v${version}`]);
     return true;


### PR DESCRIPTION
This pull request includes updates to the project documentation and improvements to the `publish` script for handling Git tags. The most important changes include adding badges to the `README.md` for better visibility of project status and enhancing the `checkGitTagExists` function to fetch remote tags before checking their existence locally.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R7): Added CI status, npm version, download counts, and license badges to improve visibility and provide quick access to project metrics.

### Script Enhancements:

* [`script/publish.ts`](diffhunk://#diff-c84ffa38c07803e24c4e107bce6a311ce6b621e713c935f0766f53e5cdd9683fR23-R31): Updated the `checkGitTagExists` function to fetch tags from the remote repository before checking their existence locally, ensuring a more accurate tag validation process.