### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mizunashi-mana/claude-code-hook-sdk/security/code-scanning/1](https://github.com/mizunashi-mana/claude-code-hook-sdk/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. In this case, the workflow only needs to read repository contents to check out code and run tests, so `contents: read` is sufficient. The best way to implement this is to add the `permissions` block at the root level of the workflow file (above `jobs:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed; just add the block in `.github/workflows/test.yml` above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
